### PR TITLE
[themes] Fixup: use valid XML attribute format for 'defer' when loading searchindex file.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,8 +61,6 @@ jobs:
       run: python --version
     - name: Install graphviz
       run: sudo apt-get install graphviz
-    - name: Install lxml dependencies
-      run: sudo apt-get install libxml2-dev libxslt-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -306,7 +306,6 @@ select = [
     "S317",  # Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents
     "S318",  # Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents
     "S319",  # Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents
-    "S320",  # Using `lxml` to parse untrusted data is known to be vulnerable to XML attacks
     "S321",  # FTP-related functions are being called. FTP is considered insecure. Use SSH/SFTP/SCP or some other encrypted protocol.
     "S323",  # Python allows using an insecure context via the `_create_unverified_context` that reverts to the previous behavior that does not validate certificates or perform hostname checks.
 #    "S324",  # Probable use of insecure hash functions in `hashlib`: `{string}`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ lint = [
 ]
 test = [
     "pytest>=6.0",
-    "lxml",  # because native XML does not support all HTML specs
     "cython>=3.0",
     "setuptools>=67.0",  # for Cython compilation
     "filelock",

--- a/sphinx/testing/util.py
+++ b/sphinx/testing/util.py
@@ -11,7 +11,6 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING
 from xml.etree.ElementTree import parse as parse_xml_etree
 
-import lxml.html
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
 
@@ -27,7 +26,6 @@ if TYPE_CHECKING:
     from xml.etree.ElementTree import ElementTree as XmlElementTree
 
     from docutils.nodes import Node
-    from lxml.etree import _ElementTree as HtmlElementTree
 
 __all__ = 'SphinxTestApp', 'SphinxTestAppWrapperForSkipBuilding'
 
@@ -77,14 +75,12 @@ def etree_parse(path: str | os.PathLike[str]) -> XmlElementTree:
     return parse_xml_etree(path)  # NoQA: S314
 
 
-def etree_html_parse(path: str | os.PathLike[str]) -> HtmlElementTree:
+def etree_html_parse(path: str | os.PathLike[str]) -> XmlElementTree:
     """Parse an HTML document as an Element tree.
 
     The source is assumed to be UTF-8 encoded.
     """
-    # allow for very large trees
-    parser = lxml.html.HTMLParser(huge_tree=True, encoding='utf-8')
-    return lxml.html.parse(path, parser=parser)
+    return parse_xml_etree(path)  # NoQA: S314
 
 
 class SphinxTestApp(sphinx.application.Sphinx):

--- a/sphinx/themes/basic/search.html
+++ b/sphinx/themes/basic/search.html
@@ -15,7 +15,7 @@
     <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block extrahead %}
-    <script src="{{ pathto('searchindex.js', 1) }}" defer></script>
+    <script src="{{ pathto('searchindex.js', 1) }}" defer="true"></script>
     <meta name="robots" content="noindex" />
     {{ super() }}
 {% endblock %}

--- a/tests/test_builders/conftest.py
+++ b/tests/test_builders/conftest.py
@@ -10,22 +10,22 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from pathlib import Path
 
-    from lxml.etree import _ElementTree
+    from xml.etree.ElementTree import ElementTree
 
-etree_cache: dict[Path, _ElementTree] = {}
+etree_cache: dict[Path, ElementTree] = {}
 
 
-def _etree_parse(source: Path) -> _ElementTree:
+def _etree_parse(source: Path) -> ElementTree:
     if source in etree_cache:
         return etree_cache[source]
 
-    # do not use etree_cache.setdefault() to avoid calling lxml.html.parse()
+    # do not use etree_cache.setdefault() to avoid calling xml.html.parse()
     etree_cache[source] = tree = etree_html_parse(source)
     return tree
 
 
 @pytest.fixture(scope='package')
-def cached_etree_parse() -> Generator[Callable[[Path], _ElementTree], None, None]:
+def cached_etree_parse() -> Generator[Callable[[Path], ElementTree], None, None]:
     """Provide caching for :func:`sphinx.testing.util.etree_html_parse`."""
     yield _etree_parse
     etree_cache.clear()

--- a/tests/test_builders/html_util.py
+++ b/tests/test_builders/html_util.py
@@ -4,15 +4,15 @@ import os
 import re
 from typing import TYPE_CHECKING
 
-import lxml.etree
-from lxml.etree import _Element as ElementLXML
-from lxml.etree import _ElementTree as ElementTreeLXML
+import xml.etree
+from xml.etree.ElementTree import Element
+from xml.etree.ElementTree import ElementTree, tostring as etree_tostring
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 
-def _get_text(node: ElementLXML) -> str:
+def _get_text(node: Element) -> str:
     if node.text is not None:
         # the node has only one text
         return node.text
@@ -22,16 +22,16 @@ def _get_text(node: ElementLXML) -> str:
 
 
 def check_xpath(
-    etree: ElementTreeLXML,
+    etree: ElementTree,
     fname: str | os.PathLike[str],
     xpath: str,
-    check: str | re.Pattern[str] | Callable[[Sequence[ElementLXML]], None] | None,
+    check: str | re.Pattern[str] | Callable[[Sequence[Element]], None] | None,
     be_found: bool = True,
 ) -> None:
-    assert isinstance(etree, ElementTreeLXML)
+    assert isinstance(etree, ElementTree)
 
     nodes = list(etree.findall(xpath))
-    assert all(isinstance(node, ElementLXML) for node in nodes)
+    assert all(isinstance(node, Element) for node in nodes)
 
     if check is None:
         assert nodes == [], ('found any nodes matching xpath '
@@ -54,7 +54,7 @@ def check_xpath(
             if all(not rex.search(_get_text(node)) for node in nodes):
                 return
 
-        context = list(map(lxml.etree.tostring, nodes))
+        context = list(map(etree_tostring, nodes))
         msg = (f'{check!r} not found in any node matching '
                f'{xpath!r} in file {os.fsdecode(fname)}: {context}')
         raise AssertionError(msg)

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -266,7 +266,6 @@ def tail_check(check):
     ('otherext.html', ".//h1", "Generated section"),
     ('otherext.html', ".//a[@href='_sources/otherext.foo.txt']", ''),
 
-    ('search.html', ".//meta[@name='robots'][@content='noindex']", ''),
 ])
 @pytest.mark.sphinx('html', tags=['testtag'],
                     confoverrides={'html_context.hckey_co': 'hcval_co'})
@@ -274,13 +273,3 @@ def tail_check(check):
 def test_html5_output(app, cached_etree_parse, fname, path, check):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check)
-
-
-@pytest.mark.sphinx('html', tags=['testtag'],
-                    confoverrides={'html_context.hckey_co': 'hcval_co'})
-@pytest.mark.test_params(shared_result='test_build_html_output')
-def test_foo(app, cached_etree_parse):
-    fname, path, check = ('includes.html', ".//div[@class='inc-startend highlight-text notranslate']//pre", '^foo')
-
-    app.build()
-    check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check, False)

--- a/tests/test_builders/test_build_html_5_output.py
+++ b/tests/test_builders/test_build_html_5_output.py
@@ -266,6 +266,7 @@ def tail_check(check):
     ('otherext.html', ".//h1", "Generated section"),
     ('otherext.html', ".//a[@href='_sources/otherext.foo.txt']", ''),
 
+    ('search.html', ".//meta[@name='robots'][@content='noindex']", ''),
 ])
 @pytest.mark.sphinx('html', tags=['testtag'],
                     confoverrides={'html_context.hckey_co': 'hcval_co'})
@@ -273,3 +274,13 @@ def tail_check(check):
 def test_html5_output(app, cached_etree_parse, fname, path, check):
     app.build()
     check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check)
+
+
+@pytest.mark.sphinx('html', tags=['testtag'],
+                    confoverrides={'html_context.hckey_co': 'hcval_co'})
+@pytest.mark.test_params(shared_result='test_build_html_output')
+def test_foo(app, cached_etree_parse):
+    fname, path, check = ('includes.html', ".//div[@class='inc-startend highlight-text notranslate']//pre", '^foo')
+
+    app.build()
+    check_xpath(cached_etree_parse(app.outdir / fname), fname, path, check, False)


### PR DESCRIPTION
### Feature or Bugfix
- Experiment / for consideration.